### PR TITLE
Allow usage of absolute time (hour:minute) when starting or stopping time tracking

### DIFF
--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -337,6 +337,13 @@ def parse_engtime(timestr):
     if not timestr or timestr.strip() == 'now':
         return now
 
+    try:
+        today = datetime.today()
+        settime = datetime.strptime(timestr, "%H:%M")
+        return today.replace(hour=settime.hour, minute=settime.minute, second=0, microsecond=1)
+    except:
+        pass
+
     match = re.match(r'(\d+|a) \s* (s|secs?|seconds?) \s+ ago $',
                      timestr, re.X)
     if match is not None:

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -285,6 +285,22 @@ def action_log(period):
               end=' ← working\n' if current == name else '\n')
 
 
+
+def action_csv():
+    data = store.load()
+    work = data['work']
+
+    for item in work:
+        start_time = parse_isotime(item['start'])
+        if 'end' in item:
+            notes=''
+            if 'notes' in item:
+                for note in item['notes']:
+                    notes+='; ' + note
+            duration = parse_isotime(item['end']) - parse_isotime(item['start'])
+            print(item['name'], ',' , item['start'] , ',' , item['end'], ',', duration ,', ' , notes)
+
+
 def action_edit():
     if "EDITOR" not in os.environ:
         raise NoEditor("Please set the 'EDITOR' environment variable")
@@ -439,6 +455,10 @@ def parse_args(argv=sys.argv):
     elif head in ['l', 'log']:
         fn = action_log
         args = {'period': tail[0] if tail else None}
+
+    elif head in ['csv']:
+        fn = action_csv
+        args = {}
 
     elif head in ['t', 'tag']:
         if not tail:

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -284,9 +284,11 @@ def action_log(period):
         print(ljust_with_color(name, name_col_len), ' ∙∙ ', item['tmsg'],
               end=' ← working\n' if current == name else '\n')
 
-
+def format_csv_time(somedatetime):
+    return parse_isotime(somedatetime).strftime('%Y-%m-%d %H:%M:%S')
 
 def action_csv():
+    sep = '|'
     data = store.load()
     work = data['work']
 
@@ -296,9 +298,9 @@ def action_csv():
             notes=''
             if 'notes' in item:
                 for note in item['notes']:
-                    notes+='; ' + note
+                    notes+= note + ' ; '
             duration = parse_isotime(item['end']) - parse_isotime(item['start'])
-            print(item['name'], ',' , item['start'] , ',' , item['end'], ',', duration ,', ' , notes)
+            print(item['name'],sep , format_csv_time(item['start']) ,sep , format_csv_time(item['end']), sep, duration, sep, notes)
 
 
 def action_edit():

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -245,8 +245,13 @@ def action_status():
     start_time = parse_isotime(current['start'])
     diff = timegap(start_time, datetime.utcnow())
 
-    print('You have been working on {0} for {1}.'.format(
-        green(current['name']), diff))
+    isotime_local = isotime_utc_to_local(current['start'])
+    start_h_m = isotime_local.strftime('%H:%M')
+    now_time_str = datetime.now().strftime('%H:%M');
+
+    print('You have been working on {0} for {1}, since {2}; It is now {3}.'
+          .format(green(current['name']), yellow(diff), 
+                  yellow(start_h_m), yellow(now_time_str)))
 
     if 'notes' in current:
         for note in current['notes']:

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -302,11 +302,14 @@ def action_log(period):
 
 def format_csv_time(somedatetime):
     local_dt = isotime_utc_to_local(somedatetime)
-    return local_dt.strftime('%Y-%m-%d %H:%M:%S')
+    return local_dt.strftime('%H:%M')
 
 def extract_day(datetime_local_tz):
     local_dt = isotime_utc_to_local(datetime_local_tz)
     return local_dt.strftime('%Y-%m-%d')
+
+def remove_seconds(timedelta):
+    return ':'.join(str(timedelta).split(':')[:2])
 
 def action_csv():
     sep = '|'
@@ -321,7 +324,7 @@ def action_csv():
                 for note in item['notes']:
                     notes+= note + ' ; '
             duration = parse_isotime(item['end']) - parse_isotime(item['start'])
-            print(extract_day(item['start']), sep, item['name'],sep , format_csv_time(item['start']) ,sep , format_csv_time(item['end']), sep, duration, sep, notes , sep)
+            print(extract_day(item['start']), sep, item['name'],sep , format_csv_time(item['start']) ,sep , format_csv_time(item['end']), sep, remove_seconds(duration), sep, notes , sep)
 
 
 def action_edit():

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -248,6 +248,10 @@ def action_status():
     print('You have been working on {0} for {1}.'.format(
         green(current['name']), diff))
 
+    if 'notes' in current:
+        for note in current['notes']:
+            print('  * ', note)
+
 
 def action_log(period):
     data = store.load()

--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -436,7 +436,7 @@ def parse_args(argv=sys.argv):
         fn = action_edit
         args = {}
 
-    elif head in ['o', 'on']:
+    elif head in ['o', 'on' , 'start']:
         if not tail:
             raise BadArguments("Need the name of whatever you are working on.")
 
@@ -446,7 +446,7 @@ def parse_args(argv=sys.argv):
             'time': to_datetime(' '.join(tail[1:])),
         }
 
-    elif head in ['f', 'fin']:
+    elif head in ['f', 'fin', 'stop']:
         fn = action_fin
         args = {'time': to_datetime(' '.join(tail))}
 


### PR DESCRIPTION
The change is non-breaking and does not negatively impact
existing functionality. (Adding relative time still works)

Example usage:
```
$ ti on 'very secret undertaking' 13:15
Start working on very secret undertaking.
$ ti fin 13:30
So you stopped working on very secret undertaking.
$ ti log
very secret undertaking  ∙∙  15 minutes
```
