### PR TITLE
Add day as a new time unit option to the existing minute and hours.

### DIFF
--- a/ti/__init__.py
+++ b/ti/__init__.py
@@ -355,6 +355,12 @@ def parse_engtime(timestr):
         n = match.group(1)
         hours = 1 if n in ['a', 'an'] else int(n)
         return now - timedelta(hours=hours)
+      
+    match = re.match(r'(\d+|a) \s* (ds?|days?) \s+ ago $', timestr, re.X)
+    if match is not None:
+        n = match.group(1)
+        days = 1 if n in ['a'] else int(n)
+        return now - timedelta(hours=24*days)
 
     raise BadTime("Don't understand the time %r" % (timestr,))
 


### PR DESCRIPTION
Rationale:

- oftentimes, I find that I need to interrupt a tasks days after I left it open: due to week-end or vacation or busy on other things.
-     being able to say this task stopped 8 days ago is more productive rather than multiplying mentally by 24 to specify hours instead, making calculation mistakes on the way.
